### PR TITLE
Adapt to new topics and Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,23 +3,24 @@ project(sdh_rviz_control_panel)
 
 add_compile_options(-std=c++11)
 
-find_package(catkin REQUIRED)
-find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(catkin REQUIRED COMPONENTS rviz)
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
 catkin_package(
-	DEPENDS rviz
-    CATKIN_DEPENDS
+    CATKIN_DEPENDS rviz
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
 )
 
-include(${QT_USE_FILE})
+include_directories(${catkin_INCLUDE_DIRS})
 include_directories(include/)
 
-qt4_wrap_cpp(QT_MOC include/sdh_rviz_control_panel.h)
-set(SOURCES src/sdh_rviz_control_panel.cpp ${QT_MOC})
-add_library(SDHControlPanel ${SOURCES})
-target_link_libraries(SDHControlPanel ${QT_LIBRARIES} ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES})
+add_library(SDHControlPanel src/sdh_rviz_control_panel.cpp)
+target_link_libraries(SDHControlPanel ${catkin_LIBRARIES} ${rviz_DEFAULT_PLUGIN_LIBRARIES} Qt5::Widgets)
 
 install(FILES plugin_description.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sdh_rviz_control_panel)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED)
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
 

--- a/include/sdh_rviz_control_panel.h
+++ b/include/sdh_rviz_control_panel.h
@@ -39,9 +39,9 @@ class SDHControlPanel : public rviz::Panel {
   ros::ServiceClient srvEmergencyStop_ =
       nh.serviceClient<std_srvs::Trigger>("/gripper/sdh_controller/stop");
   ros::ServiceClient srvEngage_ =
-      nh.serviceClient<std_srvs::Trigger>("/gripper/sdh_controller/engage");
+      nh.serviceClient<std_srvs::Trigger>("/gripper/sdh_controller/motor_on");
   ros::ServiceClient srvDisengage_ =
-      nh.serviceClient<std_srvs::Trigger>("/gripper/sdh_controller/disengage");
+      nh.serviceClient<std_srvs::Trigger>("/gripper/sdh_controller/motor_off");
   ros::ServiceClient srvTactileClose_ = nh.serviceClient<std_srvs::Trigger>(
       "/gripper/sdh_controller/tactile_close");
   ros::ServiceClient srvTactileOpen_ = nh.serviceClient<std_srvs::Trigger>(

--- a/include/sdh_rviz_control_panel.h
+++ b/include/sdh_rviz_control_panel.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <QtGui>
+#include <QPushButton>
+#include <QVBoxLayout>
 
 #include <ros/ros.h>
 #include <rviz/panel.h>

--- a/src/sdh_rviz_control_panel.cpp
+++ b/src/sdh_rviz_control_panel.cpp
@@ -7,8 +7,8 @@ SDHControlPanel::SDHControlPanel(QWidget* parent) : rviz::Panel(parent) {
 
   _btnInitialise = new QPushButton(tr("Initialise"));
   _btnEmergencyStop = new QPushButton(tr("Emergency Stop"));
-  _btnEngage = new QPushButton(tr("Engage"));
-  _btnDisengage = new QPushButton(tr("Disengage"));
+  _btnEngage = new QPushButton(tr("Motors ON"));
+  _btnDisengage = new QPushButton(tr("Motors OFF"));
   _btnTactileClose = new QPushButton(tr("Tactile Close"));
   _btnTactileOpen = new QPushButton(tr("Tactile Open"));
 


### PR DESCRIPTION
I implemented some fixes a while ago to test the Schunk hand. It's mainly adapting to new topic names from upstream repo and porting to Qt5 (kinetic and higher).

Although it's very unlikely that we will use the RViz plugin for the Schunk hand again, this will at least allow me to remove my custom branch :-)